### PR TITLE
ci: bump test matrix to Node.js 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
pnpm 11 requires Node.js >= 22.13, so the 20.x matrix job fails on main. Bumps to 24.x (matches release.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)